### PR TITLE
Make inheritance work (and fix warnings).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+pm_to_blib

--- a/MANIFEST
+++ b/MANIFEST
@@ -6,3 +6,4 @@ MANIFEST.SKIP
 README
 t/00_compile.t
 t/10_exponentialbackoff_test.t
+t/20_no_warnings.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,7 @@
+\.git
+\.sw.$
+pm_to_blib
+MYMETA\..*
+blib
+Makefile
+\.tar\.gz

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,9 @@ WriteMakefile(
     VERSION_FROM      => 'lib/LWP/UserAgent/ExponentialBackoff.pm',
     PREREQ_PM         => {
         LWP::UserAgent => 0,
-    }, 
+    },
+    TEST_REQUIRES     => {
+        'Test::NoWarnings' => 0,
+    },
     'dist'         => { COMPRESS => 'gzip -6f', SUFFIX => 'gz', },
 );

--- a/lib/LWP/UserAgent/ExponentialBackoff.pm
+++ b/lib/LWP/UserAgent/ExponentialBackoff.pm
@@ -1,7 +1,7 @@
 use LWP::UserAgent;
 
 package LWP::UserAgent::ExponentialBackoff;
-$VERSION = '0.04';
+$VERSION = '0.05';
 @ISA     = ("LWP::UserAgent");
 my @FAILCODES = qw(408 500 502 503 504);
 

--- a/lib/LWP/UserAgent/ExponentialBackoff.pm
+++ b/lib/LWP/UserAgent/ExponentialBackoff.pm
@@ -22,7 +22,7 @@ sub new {
 	$tolerance = .20 unless defined $tolerance;
 	my $failCodes = delete $cnf{failCodes};
 	$failCodes = { map { $_ => $_ } @FAILCODES } unless defined $failCodes;
-	my $self = $class->SUPER::new(@_);
+	my $self = $class->SUPER::new(%cnf);
 	$self = bless {
 		%{$self},
 		sum          => $sum,

--- a/t/10_exponentialbackoff_test.t
+++ b/t/10_exponentialbackoff_test.t
@@ -1,6 +1,8 @@
 
 # Time-stamp: "0";
 use strict;
+use warnings;
+
 use Test;
 BEGIN { plan tests => 15 }
 

--- a/t/10_exponentialbackoff_test.t
+++ b/t/10_exponentialbackoff_test.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Test;
-BEGIN { plan tests => 15 }
+BEGIN { plan tests => 16 }
 
 #use LWP::Debug ('+');
 
@@ -32,6 +32,13 @@ my $after_request = sub {
 };
 
 my %options = (minBackoff   => 3, before_request => $before_request, after_request => $after_request);
+
+my $agent_string =
+    LWP::UserAgent->new->agent
+    . "/ExponentialBackoff/"
+    . $LWP::UserAgent::ExponentialBackoff::VERSION;
+
+$options{agent} = $agent_string;
 
 my $browser = LWP::UserAgent::ExponentialBackoff->new(%options);
 
@@ -117,8 +124,14 @@ print "# After_count: $after_count\n";
 ok $after_count,  1;
 
 
+# test 15
+print "# Make sure Inheritance works\n";
+ok $browser->agent, $agent_string;
+
+
+
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 print "# Okay, bye from ", __FILE__, "\n";
-# test 15
+# test 16
 ok 1;
 

--- a/t/20_no_warnings.t
+++ b/t/20_no_warnings.t
@@ -1,0 +1,12 @@
+#!/usr/local/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+use Test::NoWarnings;
+
+use LWP::UserAgent::ExponentialBackoff;
+
+$^W = 1;    # Set global warnings.
+my $agent = LWP::UserAgent::ExponentialBackoff->new();


### PR DESCRIPTION
You were calling SUPER::new->(@_), but since the package name was still in @_  what you were passing to it was no longer a hash (so LWP::UserAgent just ignored it, basically, because it's not doing a "use warnings". So if anyone wanted to add options that go to the parent class, it wouldn't work.  I tested this two ways: by ensuring there were no warnings even with the "-w" switch (which is how I figured out what the problem was),  and by testing inheritance (which I had noticed didn't work a couple of weeks ago, but thought it was because of using ISA instead of the newer "use base" (which is already semi-deprecated...).

I also added .gitignore and MANIFEST.SKIP (the latter was already claimed to be there).

Thanks for the module!  It's very useful.
